### PR TITLE
Update repository url and readme

### DIFF
--- a/Analytics/Analytics.csproj
+++ b/Analytics/Analytics.csproj
@@ -15,6 +15,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <description>This is our custom build of the segment analytics SDK with compatibility changes to support netstandard2.0, the correct version of newtonsoft json, and also some changes to allow us to set the host endpoint</description>
     <summary>Custom build for the Segment Analytics SDK</summary>
+    <RepositoryUrl>https://github.com/orgs/articulate/packages</RepositoryUrl>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This package is not currently built and deployed by AppVeyor like most of our ot
 - Update the version in `Analytics\Analytics.cs`
 - Update the version in `Analytics\Analytics.csproj`
 - Run `dotnet pack -c Release`
-- Deploy the resulting `.nupkg` file to GitHub packages.
+- Run `dotnet nuget push Analytics\bin\Release\*.nupkg --source "github"`
 
 ## License
 


### PR DESCRIPTION
Update the csproj to include a repository url and the readme with instructions on how to deploy the resulting package. Using the `dotnet nuget push` command in the readme, I was able to successfully push the package to our Github packages repository:

https://github.com/articulate/nuget-legacy/pkgs/nuget/Articulate.Segment.Analytics

@akindle , oddly enough, the command does complain about not using an api key, but it still successfully deployed the package. I don't know if this means that there's some security check that's not enabled for this particular package, but maybe it's something we should investigate. Then again, it may have used the personal access token I have stored in git in order to access the various Articulate repos - I really have no idea. Do you have any guesses as to why this succeeded?